### PR TITLE
Update and lock down the dependencies a bit.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,20 +1,20 @@
 {
-	"name": "SiliconFeelings",
-	"description": "",
-	"version": "0.0.1",
-	"author": "Bradley",
-	"private": true,
-	"dependencies": {
-		"config": "*",
-		"dotenv": "*",
-		"express": "3.3.5",
-		"node.extend": "*",
-		"punycode": "*",
-		"socket.io": "1.0.4",
-		"twit": "*",
-		"underscore": "*"
-	},
-	"devDependencies": {
-		"mocha": "~1.13.0"
-	}
+  "name": "SiliconFeelings",
+  "description": "",
+  "version": "0.0.1",
+  "author": "Bradley",
+  "private": true,
+  "dependencies": {
+    "config": "^1.21.0",
+    "dotenv": "^2.0.0",
+    "express": "^3.21.2",
+    "node.extend": "^1.1.5",
+    "punycode": "^2.0.0",
+    "socket.io": "^1.4.8",
+    "twit": "^2.2.4",
+    "underscore": "^1.8.3"
+  },
+  "devDependencies": {
+    "mocha": "~1.13.0"
+  }
 }


### PR DESCRIPTION
- Update socket.io
- Update express (not to the latest, but latest of 3.x.x)
- Lock other dependencies down a bit more.

socket.io has had some fixes for websocket leaks.

express has a couple years of fixes, and should still be compatible.
